### PR TITLE
Add multiple security vulnerabilities to VulnUserManager

### DIFF
--- a/src/main/java/com/enterprise/vulnusermanager/config/SecurityConfig.java
+++ b/src/main/java/com/enterprise/vulnusermanager/config/SecurityConfig.java
@@ -9,7 +9,9 @@ import org.springframework.security.web.SecurityFilterChain;
 /**
  * SecurityConfig
  * Spring Security Configuration
- * Currently permits all requests - to be secured later
+ * VULNERABLE: CWE-352 Cross-Site Request Forgery (CSRF)
+ * CSRF protection is DISABLED - exposes state-changing operations to CSRF attacks
+ * INTENTIONALLY VULNERABLE for SAST detection
  */
 @Configuration
 @EnableWebSecurity
@@ -17,8 +19,11 @@ public class SecurityConfig {
 
     /**
      * Configure security filter chain
+     * VULNERABLE: CWE-352 CSRF protection DISABLED
      * WARNING: All endpoints are publicly accessible (permitAll)
+     * WARNING: State-changing operations (POST, PUT, DELETE) are vulnerable to CSRF
      * HTTP Basic authentication is configured but not enforced
+     * INTENTIONALLY VULNERABLE for SAST detection
      * @param http the HttpSecurity to configure
      * @return configured SecurityFilterChain
      * @throws Exception if configuration fails
@@ -26,7 +31,9 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-            .csrf(csrf -> csrf.disable()) // CSRF protection disabled
+            // VULNERABLE: CSRF protection explicitly disabled (CWE-352)
+            // This allows Cross-Site Request Forgery attacks on state-changing endpoints
+            .csrf(csrf -> csrf.disable())
             .authorizeHttpRequests(auth -> auth
                 .anyRequest().permitAll() // All requests permitted without authentication
             )

--- a/src/main/java/com/enterprise/vulnusermanager/controller/ArrayController.java
+++ b/src/main/java/com/enterprise/vulnusermanager/controller/ArrayController.java
@@ -10,8 +10,8 @@ import java.util.Map;
 
 /**
  * ArrayController
- * VULNERABLE: CWE-787 Out-of-bounds Write
- * Demonstrates buffer overflow vulnerability through unchecked array writes
+ * VULNERABLE: CWE-787 Out-of-bounds Write & CWE-125 Out-of-bounds Read
+ * Demonstrates buffer overflow and out-of-bounds read vulnerabilities
  * INTENTIONALLY VULNERABLE for SAST detection
  */
 @RestController
@@ -39,6 +39,26 @@ public class ArrayController {
         log.warn("SECURITY WARNING: No bounds checking - CWE-787 Out-of-bounds Write vulnerability!");
 
         Map<String, Object> result = arrayService.writeToBuffer(index, value);
+
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * VULNERABLE: Out-of-bounds Read Endpoint (CWE-125)
+     * Accepts index without bounds checking
+     * Reads from a fixed-size buffer (size 10) without validation
+     * INTENTIONALLY VULNERABLE for SAST detection
+     * @param request JSON containing index
+     * @return the read character and buffer info as JSON
+     */
+    @PostMapping("/array-read")
+    public ResponseEntity<Map<String, Object>> readFromArray(@RequestBody Map<String, Object> request) {
+        Integer index = (Integer) request.get("index");
+
+        log.info("POST /api/array-read - Reading from array at index: {}", index);
+        log.warn("SECURITY WARNING: No bounds checking - CWE-125 Out-of-bounds Read vulnerability!");
+
+        Map<String, Object> result = arrayService.readFromBuffer(index);
 
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/enterprise/vulnusermanager/controller/FileController.java
+++ b/src/main/java/com/enterprise/vulnusermanager/controller/FileController.java
@@ -1,0 +1,123 @@
+package com.enterprise.vulnusermanager.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+/**
+ * FileController
+ * VULNERABLE: CWE-22 Path Traversal & CWE-434 Unrestricted File Upload
+ * Demonstrates multiple file-related vulnerabilities
+ * INTENTIONALLY VULNERABLE for SAST detection
+ */
+@RestController
+@RequestMapping("/api")
+@Slf4j
+public class FileController {
+
+    private static final String UPLOAD_DIR = "/app/uploads/";
+
+    /**
+     * VULNERABLE: Path Traversal Endpoint (CWE-22)
+     * Downloads files without path validation or canonicalization
+     * Allows directory traversal attacks (e.g., ../../etc/passwd)
+     * NO path sanitization - INTENTIONALLY VULNERABLE for SAST detection
+     * @param path the file path from user input (user-controlled)
+     * @return file contents as byte array
+     */
+    @GetMapping("/download-file")
+    public ResponseEntity<byte[]> downloadFile(@RequestParam String path) {
+        log.info("GET /api/download-file?path={} - VULNERABLE Path Traversal endpoint", path);
+        log.warn("SECURITY WARNING: No path validation - CWE-22 Path Traversal vulnerability!");
+
+        try {
+            // VULNERABLE: Direct concatenation without canonicalization or validation
+            // Allows path traversal attacks like "../../etc/passwd"
+            String fullPath = UPLOAD_DIR + path;
+            log.warn("VULNERABLE: Accessing file at: {}", fullPath);
+
+            // VULNERABLE: Uses FileInputStream without path validation
+            File file = new File(fullPath);
+            FileInputStream fis = new FileInputStream(file);
+            byte[] fileBytes = fis.readAllBytes();
+            fis.close();
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+            headers.setContentDispositionFormData("attachment", path);
+
+            log.warn("Successfully served file without path validation!");
+            return new ResponseEntity<>(fileBytes, headers, HttpStatus.OK);
+
+        } catch (IOException e) {
+            log.error("Error reading file: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(("Error reading file: " + e.getMessage()).getBytes());
+        }
+    }
+
+    /**
+     * VULNERABLE: Unrestricted File Upload Endpoint (CWE-434)
+     * Accepts file uploads without extension validation or virus checking
+     * Allows uploading dangerous files like .jsp, .jspx, .exe, .sh
+     * NO file type validation - INTENTIONALLY VULNERABLE for SAST detection
+     * @param file the uploaded file (no validation)
+     * @return success message with file location
+     */
+    @PostMapping("/upload-profile")
+    public ResponseEntity<Map<String, String>> uploadProfile(@RequestParam("file") MultipartFile file) {
+        log.info("POST /api/upload-profile - VULNERABLE Unrestricted File Upload endpoint");
+        log.warn("SECURITY WARNING: No file extension or content validation - CWE-434 Unrestricted File Upload vulnerability!");
+
+        if (file.isEmpty()) {
+            return ResponseEntity.badRequest()
+                    .body(Map.of("error", "File is empty"));
+        }
+
+        try {
+            // VULNERABLE: No file extension validation
+            // VULNERABLE: No content type validation
+            // VULNERABLE: No virus scanning
+            // Allows uploading .jsp, .jspx, .exe, .sh, etc.
+
+            String filename = file.getOriginalFilename();
+            log.warn("VULNERABLE: Uploading file without validation: {}", filename);
+            log.warn("VULNERABLE: No check for dangerous extensions (.jsp, .jspx, .exe, .sh)");
+
+            // Create upload directory if it doesn't exist
+            File uploadDir = new File(UPLOAD_DIR);
+            if (!uploadDir.exists()) {
+                uploadDir.mkdirs();
+            }
+
+            // VULNERABLE: Direct file write without any validation
+            Path filePath = Paths.get(UPLOAD_DIR + filename);
+            Files.write(filePath, file.getBytes());
+
+            log.warn("File uploaded WITHOUT security validation to: {}", filePath);
+
+            return ResponseEntity.ok(Map.of(
+                    "message", "File uploaded successfully (no validation)",
+                    "filename", filename,
+                    "path", filePath.toString(),
+                    "warning", "No extension or virus check performed"
+            ));
+
+        } catch (IOException e) {
+            log.error("Error uploading file: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "Error uploading file: " + e.getMessage()));
+        }
+    }
+
+}

--- a/src/main/java/com/enterprise/vulnusermanager/controller/FinanceController.java
+++ b/src/main/java/com/enterprise/vulnusermanager/controller/FinanceController.java
@@ -1,0 +1,74 @@
+package com.enterprise.vulnusermanager.controller;
+
+import com.enterprise.vulnusermanager.entity.User;
+import com.enterprise.vulnusermanager.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+/**
+ * FinanceController
+ * VULNERABLE: CWE-352 Cross-Site Request Forgery (CSRF)
+ * Demonstrates CSRF vulnerability through state-changing operations without token validation
+ * CSRF protection is DISABLED in SecurityConfig
+ * INTENTIONALLY VULNERABLE for SAST detection
+ */
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Slf4j
+public class FinanceController {
+
+    private final UserService userService;
+
+    /**
+     * VULNERABLE: Transfer Funds Endpoint (CWE-352)
+     * Performs state-changing operation (fund transfer) without CSRF token validation
+     * CSRF protection is disabled in SecurityConfig
+     * NO authentication or authorization required
+     * INTENTIONALLY VULNERABLE for SAST detection
+     * @param request JSON containing fromUserId, toUserId, and amount
+     * @return success message with updated balances
+     */
+    @PostMapping("/transfer-funds")
+    public ResponseEntity<Map<String, Object>> transferFunds(@RequestBody Map<String, Object> request) {
+        Long fromUserId = ((Number) request.get("fromUserId")).longValue();
+        Long toUserId = ((Number) request.get("toUserId")).longValue();
+        Double amount = ((Number) request.get("amount")).doubleValue();
+
+        log.info("POST /api/transfer-funds - Transferring {} from user {} to user {}", amount, fromUserId, toUserId);
+        log.warn("SECURITY WARNING: CSRF protection disabled - CWE-352 CSRF vulnerability!");
+        log.warn("SECURITY WARNING: No authentication or session validation!");
+
+        // VULNERABLE: No CSRF token check
+        // VULNERABLE: No authentication check
+        // VULNERABLE: No authorization check
+
+        User fromUser = userService.findUserById(fromUserId)
+                .orElseThrow(() -> new RuntimeException("Source user not found"));
+        User toUser = userService.findUserById(toUserId)
+                .orElseThrow(() -> new RuntimeException("Destination user not found"));
+
+        // Perform transfer without any security checks
+        fromUser.setBalance(fromUser.getBalance() - amount);
+        toUser.setBalance(toUser.getBalance() + amount);
+
+        userService.saveUser(fromUser);
+        userService.saveUser(toUser);
+
+        log.warn("Transfer completed WITHOUT CSRF protection or authentication!");
+
+        return ResponseEntity.ok(Map.of(
+                "message", "Transfer successful (no CSRF protection)",
+                "fromUser", fromUser.getUsername(),
+                "toUser", toUser.getUsername(),
+                "amount", amount,
+                "fromUserBalance", fromUser.getBalance(),
+                "toUserBalance", toUser.getBalance()
+        ));
+    }
+
+}

--- a/src/main/java/com/enterprise/vulnusermanager/controller/ResourceController.java
+++ b/src/main/java/com/enterprise/vulnusermanager/controller/ResourceController.java
@@ -1,0 +1,126 @@
+package com.enterprise.vulnusermanager.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * ResourceController
+ * VULNERABLE: CWE-416 Use After Free
+ * Demonstrates use-after-free pattern in Java context
+ * INTENTIONALLY VULNERABLE for SAST detection
+ */
+@RestController
+@RequestMapping("/api")
+@Slf4j
+public class ResourceController {
+
+    /**
+     * VULNERABLE: Use After Free Endpoint (CWE-416)
+     * Creates a ByteBuffer, clears it, then attempts to access it
+     * Demonstrates use-after-free pattern detectable by SAST tools
+     * INTENTIONALLY VULNERABLE for SAST detection
+     * @return resource usage information as JSON
+     */
+    @PostMapping("/use-resource")
+    public ResponseEntity<Map<String, Object>> useResource() {
+        log.info("POST /api/use-resource - VULNERABLE Use After Free endpoint");
+        log.warn("SECURITY WARNING: Use After Free pattern - CWE-416 vulnerability!");
+
+        Map<String, Object> result = new HashMap<>();
+
+        try {
+            // Allocate a ByteBuffer resource
+            ByteBuffer buffer = ByteBuffer.allocate(1024);
+            buffer.put("Sensitive data".getBytes());
+
+            log.info("ByteBuffer created and populated with data");
+            log.warn("VULNERABLE: About to 'free' the buffer and then use it");
+
+            // Store reference to the buffer's data
+            byte[] dataBeforeFree = new byte[buffer.position()];
+            buffer.flip();
+            buffer.get(dataBeforeFree);
+
+            // VULNERABLE: "Free" the buffer by clearing it
+            buffer.clear();
+            log.warn("Buffer cleared (simulating free operation)");
+
+            // VULNERABLE: Use after free - accessing buffer after clearing
+            // In C/C++ this would be a critical vulnerability
+            // In Java, SAST tools should flag this pattern
+            buffer.put("Accessing freed memory".getBytes());
+            byte[] dataAfterFree = new byte[buffer.position()];
+            buffer.flip();
+            buffer.get(dataAfterFree);
+
+            log.warn("VULNERABLE: Accessed buffer after free operation!");
+            log.warn("This pattern represents use-after-free vulnerability");
+
+            result.put("warning", "Use after free vulnerability - CWE-416");
+            result.put("beforeFree", new String(dataBeforeFree));
+            result.put("afterFree", new String(dataAfterFree));
+            result.put("vulnerability", "Buffer accessed after clear() operation");
+
+            return ResponseEntity.ok(result);
+
+        } catch (Exception e) {
+            log.error("Error in use-after-free demonstration: {}", e.getMessage());
+            result.put("error", "Error: " + e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(result);
+        }
+    }
+
+    /**
+     * VULNERABLE: Use After Free with Direct Memory (CWE-416)
+     * Uses DirectByteBuffer which is closer to native memory management
+     * Demonstrates more explicit use-after-free pattern
+     * INTENTIONALLY VULNERABLE for SAST detection
+     * @return resource usage information as JSON
+     */
+    @PostMapping("/use-direct-resource")
+    public ResponseEntity<Map<String, Object>> useDirectResource() {
+        log.info("POST /api/use-direct-resource - VULNERABLE Use After Free endpoint (direct memory)");
+        log.warn("SECURITY WARNING: Use After Free with direct memory - CWE-416 vulnerability!");
+
+        Map<String, Object> result = new HashMap<>();
+
+        try {
+            // Allocate direct ByteBuffer (uses native memory)
+            ByteBuffer directBuffer = ByteBuffer.allocateDirect(1024);
+            directBuffer.put("Critical system data".getBytes());
+
+            log.info("Direct ByteBuffer created (native memory)");
+
+            // Get position before "freeing"
+            int position = directBuffer.position();
+
+            // VULNERABLE: Simulate freeing the resource
+            directBuffer.clear();
+            directBuffer = null; // Simulate deallocation
+            log.warn("VULNERABLE: Direct buffer cleared and dereferenced");
+
+            // VULNERABLE: Try to use after "free"
+            // This simulates accessing memory after it's been freed
+            log.warn("VULNERABLE: Attempting to use freed resource!");
+
+            result.put("warning", "Use after free vulnerability with direct memory - CWE-416");
+            result.put("vulnerability", "DirectByteBuffer accessed after clear and null assignment");
+            result.put("details", "This pattern simulates use-after-free in native memory context");
+
+            return ResponseEntity.ok(result);
+
+        } catch (Exception e) {
+            log.error("Error in use-after-free demonstration: {}", e.getMessage());
+            result.put("error", "Error: " + e.getMessage());
+            result.put("note", "Exception demonstrates use-after-free vulnerability");
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(result);
+        }
+    }
+
+}

--- a/src/main/java/com/enterprise/vulnusermanager/controller/SystemController.java
+++ b/src/main/java/com/enterprise/vulnusermanager/controller/SystemController.java
@@ -1,0 +1,87 @@
+package com.enterprise.vulnusermanager.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * SystemController
+ * VULNERABLE: CWE-78 OS Command Injection
+ * Demonstrates OS command injection vulnerability through unsafe command execution
+ * INTENTIONALLY VULNERABLE for SAST detection
+ */
+@RestController
+@RequestMapping("/api")
+@Slf4j
+public class SystemController {
+
+    /**
+     * VULNERABLE: OS Command Injection Endpoint (CWE-78)
+     * Executes system ping command with user-controlled input
+     * Uses Runtime.getRuntime().exec() with string concatenation
+     * NO input validation, NO shell escaping - INTENTIONALLY VULNERABLE
+     * @param host the hostname or IP address to ping (user-controlled)
+     * @return command output as JSON
+     */
+    @PostMapping("/system-ping")
+    public ResponseEntity<Map<String, Object>> systemPing(@RequestParam String host) {
+        log.info("POST /api/system-ping?host={} - VULNERABLE OS Command Injection endpoint", host);
+        log.warn("SECURITY WARNING: Command injection via string concatenation - CWE-78 OS Command Injection vulnerability!");
+
+        Map<String, Object> result = new HashMap<>();
+
+        try {
+            // VULNERABLE: Direct string concatenation without escaping or validation
+            // Allows command injection like: "google.com; cat /etc/passwd"
+            // or "google.com && whoami" or "google.com | ls -la"
+            String command = "ping " + host;
+
+            log.warn("VULNERABLE: Executing command without validation: {}", command);
+            log.warn("VULNERABLE: No shell escaping - allows command injection!");
+
+            // VULNERABLE: Runtime.exec() with concatenated user input
+            Process process = Runtime.getRuntime().exec(command);
+
+            // Capture command output
+            BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+            BufferedReader errorReader = new BufferedReader(new InputStreamReader(process.getErrorStream()));
+
+            StringBuilder output = new StringBuilder();
+            StringBuilder errorOutput = new StringBuilder();
+            String line;
+
+            while ((line = reader.readLine()) != null) {
+                output.append(line).append("\n");
+            }
+
+            while ((line = errorReader.readLine()) != null) {
+                errorOutput.append(line).append("\n");
+            }
+
+            int exitCode = process.waitFor();
+
+            result.put("command", command);
+            result.put("output", output.toString());
+            result.put("error", errorOutput.toString());
+            result.put("exitCode", exitCode);
+            result.put("warning", "Command executed without input validation - CWE-78");
+
+            log.warn("Command executed WITHOUT input validation or sanitization!");
+
+            return ResponseEntity.ok(result);
+
+        } catch (Exception e) {
+            log.error("Error executing command: {}", e.getMessage());
+            result.put("error", "Error executing command: " + e.getMessage());
+            result.put("host", host);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(result);
+        }
+    }
+
+}

--- a/src/main/java/com/enterprise/vulnusermanager/controller/UserController.java
+++ b/src/main/java/com/enterprise/vulnusermanager/controller/UserController.java
@@ -103,4 +103,44 @@ public class UserController {
         return modelAndView;
     }
 
+    /**
+     * VULNERABLE: SQL Injection Search Endpoint (CWE-89)
+     * Searches users using unsafe string concatenation in JPQL query
+     * NO parameterized query - INTENTIONALLY VULNERABLE for SAST detection
+     * @param query the search query parameter from user
+     * @return list of users matching the search
+     */
+    @GetMapping("/search-users")
+    public ResponseEntity<List<User>> searchUsers(@RequestParam String query) {
+        log.info("GET /api/search-users?query={} - VULNERABLE SQL Injection endpoint", query);
+        log.warn("SECURITY WARNING: SQL Injection via string concatenation - CWE-89");
+
+        List<User> users = userService.searchUsers(query);
+        return ResponseEntity.ok(users);
+    }
+
+    /**
+     * VULNERABLE: Missing Authorization (CWE-862)
+     * Deletes any user without authentication or authorization checks
+     * NO @PreAuthorize, NO role verification - INTENTIONALLY VULNERABLE
+     * @param id the user ID to delete
+     * @return success message
+     */
+    @DeleteMapping("/users/{id}")
+    public ResponseEntity<String> deleteUser(@PathVariable Long id) {
+        log.info("DELETE /api/users/{} - VULNERABLE Missing Authorization endpoint", id);
+        log.warn("SECURITY WARNING: No authorization check - CWE-862 Missing Authorization vulnerability!");
+
+        // No authentication check
+        // No role verification
+        // Anyone can delete any user
+        userService.findUserById(id).ifPresent(user -> {
+            log.warn("Deleting user without authorization: {}", user.getUsername());
+            // Note: We're not actually implementing delete in the service for simplicity
+            // But the vulnerability is present - no authorization check
+        });
+
+        return ResponseEntity.ok("User deleted (no authorization required)");
+    }
+
 }

--- a/src/main/java/com/enterprise/vulnusermanager/entity/User.java
+++ b/src/main/java/com/enterprise/vulnusermanager/entity/User.java
@@ -39,4 +39,11 @@ public class User {
     @Column(nullable = false)
     private String role;
 
+    /**
+     * User account balance
+     * Used for demonstrating CSRF vulnerability (CWE-352)
+     */
+    @Column(nullable = false)
+    private Double balance = 0.0;
+
 }

--- a/src/main/java/com/enterprise/vulnusermanager/service/ArrayService.java
+++ b/src/main/java/com/enterprise/vulnusermanager/service/ArrayService.java
@@ -8,13 +8,16 @@ import java.util.Map;
 
 /**
  * ArrayService
- * VULNERABLE: CWE-787 Out-of-bounds Write
- * Performs unchecked writes to a fixed-size buffer
+ * VULNERABLE: CWE-787 Out-of-bounds Write & CWE-125 Out-of-bounds Read
+ * Performs unchecked reads and writes to a fixed-size buffer
  * INTENTIONALLY VULNERABLE for SAST detection
  */
 @Service
 @Slf4j
 public class ArrayService {
+
+    // Fixed-size buffer for demonstrating out-of-bounds read
+    private final char[] globalBuffer = {'H', 'e', 'l', 'l', 'o', 'W', 'o', 'r', 'l', 'd'};
 
     /**
      * VULNERABLE: Out-of-bounds Write (CWE-787)
@@ -42,6 +45,35 @@ public class ArrayService {
         result.put("index", index);
         result.put("writtenValue", value.charAt(0));
         result.put("bufferSize", buffer.length);
+
+        return result;
+    }
+
+    /**
+     * VULNERABLE: Out-of-bounds Read (CWE-125)
+     * Reads from a fixed-size buffer without bounds checking
+     * NO INPUT VALIDATION - accepts any index value
+     * NO TRY-CATCH - allows exceptions to propagate
+     * INTENTIONALLY VULNERABLE for SAST detection
+     * @param index the array index to read from (UNCHECKED!)
+     * @return Map containing the read character and operation details
+     */
+    public Map<String, Object> readFromBuffer(Integer index) {
+        log.info("Reading from buffer at index: {}", index);
+        log.warn("SECURITY WARNING: NO BOUNDS CHECKING - CWE-125 Out-of-bounds Read vulnerability!");
+        log.warn("Buffer size is {} but no validation on index!", globalBuffer.length);
+
+        // VULNERABLE: No bounds checking before array access
+        // This can cause ArrayIndexOutOfBoundsException or read sensitive memory
+        char c = globalBuffer[index];
+
+        log.info("Successfully read '{}' from buffer[{}]", c, index);
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("readValue", String.valueOf(c));
+        result.put("index", index);
+        result.put("bufferSize", globalBuffer.length);
+        result.put("buffer", new String(globalBuffer));
 
         return result;
     }


### PR DESCRIPTION
## **User description**
This commit introduces 8 intentionally vulnerable endpoints for SAST detection:

1. CWE-89 (SQL Injection): GET /search-users with unsafe JPQL string concatenation
   - UserService.searchUsers() uses "SELECT u FROM User u WHERE u.username LIKE '%" + query + "%'"
   - No parameterized queries, enables SQL injection attacks

2. CWE-352 (CSRF): POST /transfer-funds without CSRF protection
   - SecurityConfig has CSRF explicitly disabled
   - FinanceController.transferFunds() changes user balance without token validation
   - Added balance field to User entity

3. CWE-22 (Path Traversal): GET /download-file with unsafe file access
   - FileController uses new FileInputStream(new File("/app/uploads/" + path))
   - No canonicalization or path validation, enables directory traversal

4. CWE-125 (Out-of-bounds Read): POST /array-read without bounds checking
   - ArrayController.readFromArray() accesses buffer[index] without validation
   - Buffer size is 10, no index range check

5. CWE-78 (OS Command Injection): POST /system-ping with unsafe exec
   - SystemController uses Runtime.getRuntime().exec("ping " + host)
   - No shell escaping or input validation

6. CWE-416 (Use After Free): POST /use-resource with buffer reuse
   - ResourceController demonstrates use-after-free pattern with ByteBuffer
   - Accesses buffer after clear() operation

7. CWE-862 (Missing Authorization): DELETE /users/{id} without auth checks
   - UserController.deleteUser() has no @PreAuthorize or role verification
   - Anyone can delete any user without authentication

8. CWE-434 (Unrestricted File Upload): POST /upload-profile without validation
   - FileController accepts any file extension (.jsp, .exe, .sh)
   - No content type validation or virus scanning

All vulnerabilities are intentionally introduced for security testing and SAST tool validation.


___

## **CodeAnt-AI Description**
Introduce intentionally vulnerable API endpoints to exercise multiple SAST rules

### What Changed
- Added POST /api/transfer-funds that moves account balance without CSRF protection, authentication, or authorization; user balances can be changed by any caller
- Added GET /api/search-users that runs a search using unsanitized input, allowing SQL injection via the search parameter
- Added DELETE /api/users/{id} that allows deleting users without any authorization checks
- Added POST /api/system-ping that executes a system ping using raw user input, returning command output (allows command injection)
- Added GET /api/download-file that serves files from the uploads directory using a user-supplied path (allows directory traversal)
- Added POST /api/upload-profile that accepts and writes uploaded files without validating extensions or content (allows dangerous uploads)
- Added POST /api/array-read and updated array write behavior so reads and writes use fixed-size buffers without bounds checks (out-of-bounds read/write observable by callers)
- Added POST /api/use-resource and POST /api/use-direct-resource endpoints that demonstrate use-after-free patterns and return diagnostic details
- Security configuration explicitly disables CSRF for all endpoints (state-changing endpoints are exposed); User entity now includes a balance field visible in transfer responses

### Impact
`✅ Detect SQL injection during SAST scans`
`✅ Detect CSRF and unauthorized fund-transfer scenarios`
`✅ Detect file upload and path-traversal vulnerabilities`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
