### PR TITLE
Implement Multiple Security Vulnerabilities for Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,353 @@
-# hello-world
-Github Tutorial
+# VulnUserManager - Intentionally Vulnerable Application
 
+⚠️ **WARNING: This application contains intentional security vulnerabilities for educational and testing purposes. DO NOT deploy to production or expose to the internet!**
 
-This is a test for git
+## Overview
+
+VulnUserManager is a deliberately vulnerable Spring Boot application designed for:
+- Static Application Security Testing (SAST) tool evaluation
+- Security training and education
+- Demonstrating common CWE (Common Weakness Enumeration) vulnerabilities
+- Testing security scanning tools like SonarQube
+
+## Technology Stack
+
+- **Java**: 17
+- **Spring Boot**: 3.2.0
+- **Database**: H2 (in-memory)
+- **Build Tool**: Maven
+- **Security**: Spring Security (intentionally misconfigured)
+
+## Running the Application
+
+### Prerequisites
+- Java 17 or higher
+- Maven 3.6+
+
+### Build and Run
+
+```bash
+# Build the application
+mvn clean package
+
+# Run the application
+mvn spring-boot:run
+
+# Or run the JAR directly
+java -jar target/vuln-user-manager-1.0.0-SNAPSHOT.jar
+```
+
+The application will start on `http://localhost:8080`
+
+## Vulnerable Endpoints
+
+### CWE-94: Code Injection
+**POST** `/api/eval-code`
+- Executes arbitrary JavaScript code using Nashorn script engine
+- No input validation or sandboxing
+- Example payload:
+```json
+{
+  "script": "java.lang.System.getProperty('user.name')"
+}
+```
+
+### CWE-20: Improper Input Validation
+**POST** `/api/register`
+- Accepts null or empty username/password
+- No validation on user registration
+- Example payload:
+```json
+{
+  "username": "",
+  "password": "",
+  "email": "test@test.com",
+  "role": "USER"
+}
+```
+
+### CWE-77: OS Command Injection
+**POST** `/api/run-command`
+- Executes system commands using ProcessBuilder
+- Uses `cmd.split(" ")` without sanitization
+- Example payload:
+```json
+{
+  "cmd": "ls -la"
+}
+```
+
+**POST** `/api/system-ping` (existing)
+- Executes ping command with Runtime.exec()
+- Query param: `host`
+
+### CWE-287: Improper Authentication
+- Plain-text password storage in User entity
+- NoOpPasswordEncoder (no BCrypt)
+- Basic Auth without session management
+- Hardcoded credentials:
+  - Username: `admin`, Password: `admin123`
+  - Username: `user`, Password: `user123`
+
+### CWE-269: Improper Privilege Management
+**POST** `/api/admin-only`
+- Manual role check with simple if statement
+- No Spring Security @PreAuthorize integration
+- Query params: `userId`, Body: `{"action": "some_action"}`
+
+### CWE-502: Deserialization of Untrusted Data
+**POST** `/api/deserialize-object`
+- Deserializes base64-encoded objects without validation
+- Uses ObjectInputStream on untrusted data
+- Example payload:
+```json
+{
+  "data": "rO0ABXQABXRlc3Q="
+}
+```
+
+### CWE-200: Exposure of Sensitive Information
+- UserService logs passwords in plain text
+- Check application logs for exposed credentials
+- Triggered on user registration
+
+### CWE-863: Incorrect Authorization
+**POST** `/api/edit-user/{id}`
+- Flawed authorization check using `==` operator on strings
+- Query param: `currentUserId`, Body: `{...updates...}`
+
+### CWE-918: Server-Side Request Forgery (SSRF)
+**GET** `/api/fetch-url`
+- Fetches content from user-provided URL
+- No URL validation or whitelist
+- Query param: `url`
+- Example: `/api/fetch-url?url=http://localhost:8080/api/users`
+
+### CWE-119: Buffer Copy without Bounds Checking
+**POST** `/api/buffer-copy`
+- Copies data to fixed-size buffer (5 chars) without size check
+- Uses System.arraycopy without validation
+- Example payload:
+```json
+{
+  "data": "HelloWorld"
+}
+```
+
+### CWE-79: Cross-Site Scripting (XSS)
+**GET** `/api/xss-profile/{username}`
+- Renders user data with th:utext (unescaped)
+- No input sanitization
+- Example: `/api/xss-profile/<script>alert(1)</script>`
+
+### CWE-89: SQL Injection
+**GET** `/api/search-users`
+- Uses string concatenation in JPQL query
+- Query param: `query`
+- Example: `/api/search-users?query=' OR '1'='1`
+
+### CWE-787: Out-of-bounds Write
+**POST** `/api/array-write`
+- Writes to array without bounds checking
+- Payload: `{"index": 20, "value": "X"}`
+
+### CWE-125: Out-of-bounds Read
+**POST** `/api/array-read`
+- Reads from array without bounds checking
+- Payload: `{"index": 20}`
+
+### CWE-22: Path Traversal
+**GET** `/api/download-file`
+- Downloads files without path validation
+- Query param: `filename`
+- Example: `/api/download-file?filename=../../etc/passwd`
+
+### CWE-434: Unrestricted File Upload
+**POST** `/api/upload-profile`
+- Accepts file uploads without extension validation
+- Multipart form data
+
+### CWE-416: Use After Free
+**POST** `/api/use-resource`
+- Clears buffer then accesses it
+- Payload: `{"data": "test"}`
+
+### CWE-352: Cross-Site Request Forgery (CSRF)
+**POST** `/api/transfer-funds`
+- CSRF protection disabled in SecurityConfig
+- No CSRF token validation
+- Payload: `{"amount": 100.0, "toUser": "victim"}`
+
+### CWE-862: Missing Authorization
+**DELETE** `/api/users/{id}`
+- No authentication or authorization checks
+- Anyone can delete any user
+
+## H2 Database Console
+
+Access the H2 console at: `http://localhost:8080/h2-console`
+
+Connection details:
+- JDBC URL: `jdbc:h2:mem:vulnuserdb`
+- Username: `sa`
+- Password: (empty)
+
+## Testing
+
+Run the integration tests:
+
+```bash
+mvn test
+```
+
+The test suite includes demonstrations of various vulnerabilities.
+
+## Scanning with SonarQube
+
+### Local SonarQube Setup
+
+1. **Install and Start SonarQube**:
+```bash
+# Using Docker
+docker run -d --name sonarqube -p 9000:9000 sonarqube:latest
+
+# Wait for SonarQube to start (check http://localhost:9000)
+# Default credentials: admin/admin
+```
+
+2. **Create a Project**:
+- Login to SonarQube at `http://localhost:9000`
+- Click "Create Project" → "Manually"
+- Project key: `vuln-user-manager`
+- Display name: `VulnUserManager`
+- Generate a token for authentication
+
+3. **Scan the Project**:
+```bash
+mvn clean verify sonar:sonar \
+  -Dsonar.projectKey=vuln-user-manager \
+  -Dsonar.projectName=VulnUserManager \
+  -Dsonar.host.url=http://localhost:9000 \
+  -Dsonar.login=YOUR_SONARQUBE_TOKEN
+```
+
+4. **View Results**:
+- Navigate to `http://localhost:9000/dashboard?id=vuln-user-manager`
+- Review detected vulnerabilities, code smells, and security hotspots
+
+### Using SonarCloud
+
+```bash
+mvn clean verify sonar:sonar \
+  -Dsonar.projectKey=YOUR_PROJECT_KEY \
+  -Dsonar.organization=YOUR_ORG \
+  -Dsonar.host.url=https://sonarcloud.io \
+  -Dsonar.login=YOUR_SONARCLOUD_TOKEN
+```
+
+### Expected SonarQube Findings
+
+SonarQube should detect the following security issues:
+
+| CWE | Severity | Description |
+|-----|----------|-------------|
+| CWE-94 | Critical | Code Injection via ScriptEngine |
+| CWE-502 | Critical | Deserialization of untrusted data |
+| CWE-77, CWE-78 | Critical | OS Command Injection |
+| CWE-89 | Critical | SQL Injection via string concatenation |
+| CWE-79 | High | Cross-Site Scripting (XSS) |
+| CWE-918 | High | Server-Side Request Forgery (SSRF) |
+| CWE-22 | High | Path Traversal |
+| CWE-287 | High | Plain-text password storage |
+| CWE-352 | High | CSRF protection disabled |
+| CWE-862 | High | Missing authorization checks |
+| CWE-20 | Medium | Improper input validation |
+| CWE-200 | Medium | Sensitive data in logs |
+| CWE-269 | Medium | Improper privilege management |
+| CWE-863 | Medium | Incorrect authorization logic |
+| CWE-787, CWE-125, CWE-119 | Medium | Buffer overflow issues |
+
+## Project Structure
+
+```
+src/
+├── main/
+│   ├── java/com/enterprise/vulnusermanager/
+│   │   ├── VulnUserManagerApplication.java
+│   │   ├── config/
+│   │   │   └── SecurityConfig.java
+│   │   ├── controller/
+│   │   │   ├── AdminController.java          (CWE-269)
+│   │   │   ├── ArrayController.java          (CWE-787, CWE-125, CWE-119)
+│   │   │   ├── CodeController.java           (CWE-94)
+│   │   │   ├── FileController.java           (CWE-22, CWE-434)
+│   │   │   ├── FinanceController.java        (CWE-352)
+│   │   │   ├── ResourceController.java       (CWE-416)
+│   │   │   ├── SerializeController.java      (CWE-502)
+│   │   │   ├── SystemController.java         (CWE-77, CWE-78)
+│   │   │   ├── UserController.java           (CWE-20, CWE-79, CWE-89, CWE-862, CWE-863)
+│   │   │   └── WebController.java            (CWE-918)
+│   │   ├── entity/
+│   │   │   └── User.java
+│   │   ├── repository/
+│   │   │   └── UserRepository.java
+│   │   └── service/
+│   │       ├── ArrayService.java
+│   │       └── UserService.java              (CWE-20, CWE-200)
+│   └── resources/
+│       ├── application.yml
+│       ├── static/
+│       │   └── index.html
+│       └── templates/
+│           └── profile.html                  (CWE-79)
+└── test/
+    └── java/com/enterprise/vulnusermanager/
+        └── VulnerableAppTest.java
+```
+
+## Security Best Practices (What NOT to do)
+
+This application violates numerous security best practices:
+
+1. ❌ **Never** execute user-provided code
+2. ❌ **Never** store passwords in plain text
+3. ❌ **Never** use string concatenation in SQL/JPQL queries
+4. ❌ **Never** disable CSRF protection
+5. ❌ **Never** execute system commands with user input
+6. ❌ **Never** deserialize untrusted data
+7. ❌ **Never** render user input without escaping
+8. ❌ **Never** access files without path validation
+9. ❌ **Never** log sensitive information (passwords, tokens, etc.)
+10. ❌ **Never** perform manual authorization checks without security framework integration
+
+## Educational Purpose
+
+This application is designed to help:
+- Security engineers test SAST tools
+- Developers learn about common vulnerabilities
+- Teams practice secure code review
+- Organizations validate their security scanning pipeline
+
+## Disclaimer
+
+⚠️ **DO NOT USE IN PRODUCTION**
+
+This application is intentionally vulnerable and should only be used in:
+- Isolated development environments
+- Security training labs
+- SAST tool evaluation environments
+- Offline/air-gapped testing environments
+
+## License
+
+This project is provided for educational purposes only.
+
+## Contributing
+
+If you find additional vulnerabilities to demonstrate or improvements to the existing examples, please contribute!
+
+## References
+
+- [CWE Top 25 Most Dangerous Software Weaknesses](https://cwe.mitre.org/top25/)
+- [OWASP Top 10](https://owasp.org/www-project-top-ten/)
+- [SonarQube Security Rules](https://rules.sonarsource.com/)

--- a/src/main/java/com/enterprise/vulnusermanager/config/SecurityConfig.java
+++ b/src/main/java/com/enterprise/vulnusermanager/config/SecurityConfig.java
@@ -1,25 +1,37 @@
 package com.enterprise.vulnusermanager.config;
 
+import com.enterprise.vulnusermanager.service.UserService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 
 /**
  * SecurityConfig
  * Spring Security Configuration
  * VULNERABLE: CWE-352 Cross-Site Request Forgery (CSRF)
+ * VULNERABLE: CWE-287 Improper Authentication (plain-text passwords)
  * CSRF protection is DISABLED - exposes state-changing operations to CSRF attacks
  * INTENTIONALLY VULNERABLE for SAST detection
  */
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final UserService userService;
 
     /**
      * Configure security filter chain
      * VULNERABLE: CWE-352 CSRF protection DISABLED
+     * VULNERABLE: CWE-287 No session management, plain-text passwords
      * WARNING: All endpoints are publicly accessible (permitAll)
      * WARNING: State-changing operations (POST, PUT, DELETE) are vulnerable to CSRF
      * HTTP Basic authentication is configured but not enforced
@@ -37,9 +49,49 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .anyRequest().permitAll() // All requests permitted without authentication
             )
+            // VULNERABLE: CWE-287 - Basic Auth with NO session management
+            // Passwords compared as plain-text, no BCrypt, no secure hashing
             .httpBasic(httpBasic -> {}); // HTTP Basic auth configured but not required
 
         return http.build();
+    }
+
+    /**
+     * VULNERABLE: CWE-287 Improper Authentication
+     * Uses NoOpPasswordEncoder which stores and compares passwords as plain-text
+     * NO BCrypt, NO secure hashing - INTENTIONALLY VULNERABLE
+     * @return NoOpPasswordEncoder (deprecated and insecure)
+     */
+    @Bean
+    @SuppressWarnings("deprecation")
+    public PasswordEncoder passwordEncoder() {
+        // VULNERABLE: NoOpPasswordEncoder stores passwords in plain-text
+        // This is deprecated and should NEVER be used in production
+        return NoOpPasswordEncoder.getInstance();
+    }
+
+    /**
+     * VULNERABLE: In-memory user store with plain-text passwords
+     * CWE-287: No secure password storage, no session management
+     * INTENTIONALLY VULNERABLE for SAST detection
+     * @return UserDetailsService with plain-text passwords
+     */
+    @Bean
+    public UserDetailsService userDetailsService() {
+        // VULNERABLE: Hardcoded credentials with plain-text passwords
+        InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
+
+        manager.createUser(User.withUsername("admin")
+                .password("admin123") // Plain-text password - CWE-287
+                .roles("ADMIN")
+                .build());
+
+        manager.createUser(User.withUsername("user")
+                .password("user123") // Plain-text password - CWE-287
+                .roles("USER")
+                .build());
+
+        return manager;
     }
 
 }

--- a/src/main/java/com/enterprise/vulnusermanager/controller/AdminController.java
+++ b/src/main/java/com/enterprise/vulnusermanager/controller/AdminController.java
@@ -1,0 +1,79 @@
+package com.enterprise.vulnusermanager.controller;
+
+import com.enterprise.vulnusermanager.entity.User;
+import com.enterprise.vulnusermanager.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * AdminController
+ * VULNERABLE: CWE-269 Improper Privilege Management
+ * Demonstrates improper privilege management through flawed role checking
+ * INTENTIONALLY VULNERABLE for SAST detection
+ */
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Slf4j
+public class AdminController {
+
+    private final UserService userService;
+
+    /**
+     * VULNERABLE: Improper Privilege Management (CWE-269)
+     * Admin-only endpoint with flawed role check
+     * Uses manual if statement instead of Spring Security @PreAuthorize
+     * Bypasses Spring Security's role-based access control
+     * INTENTIONALLY VULNERABLE for SAST detection
+     * @param userId the user ID to check for admin role
+     * @param action the admin action to perform
+     * @return response indicating if action was allowed
+     */
+    @PostMapping("/admin-only")
+    public ResponseEntity<Map<String, Object>> adminOnlyAction(
+            @RequestParam Long userId,
+            @RequestBody Map<String, String> action) {
+
+        log.info("POST /api/admin-only - VULNERABLE Improper Privilege Management endpoint");
+        log.warn("SECURITY WARNING: Manual role check bypassing Spring Security - CWE-269 Improper Privilege Management!");
+
+        Map<String, Object> result = new HashMap<>();
+
+        // VULNERABLE: Manual role check without Spring Security integration
+        // No @PreAuthorize annotation, no proper authorization framework
+        User user = userService.findUserById(userId).orElse(null);
+
+        if (user == null) {
+            result.put("authorized", false);
+            result.put("error", "User not found");
+            return ResponseEntity.badRequest().body(result);
+        }
+
+        log.warn("VULNERABLE: Checking role with simple if statement: user.getRole().equals(\"ADMIN\")");
+
+        // VULNERABLE: Simple string comparison without Spring Security
+        // No integration with security context, easily bypassed
+        if (user.getRole().equals("ADMIN")) {
+            log.warn("SECURITY WARNING: Role check passed WITHOUT Spring Security @PreAuthorize!");
+            result.put("authorized", true);
+            result.put("message", "Admin action executed");
+            result.put("action", action.get("action"));
+            result.put("userId", userId);
+            result.put("role", user.getRole());
+            result.put("vulnerability", "CWE-269: Manual role check without Spring Security integration");
+        } else {
+            log.warn("Role check failed: User is not ADMIN");
+            result.put("authorized", false);
+            result.put("message", "User is not authorized - not an admin");
+            result.put("role", user.getRole());
+        }
+
+        return ResponseEntity.ok(result);
+    }
+
+}

--- a/src/main/java/com/enterprise/vulnusermanager/controller/CodeController.java
+++ b/src/main/java/com/enterprise/vulnusermanager/controller/CodeController.java
@@ -1,0 +1,70 @@
+package com.enterprise.vulnusermanager.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * CodeController
+ * VULNERABLE: CWE-94 Code Injection
+ * Demonstrates code injection vulnerability through unsafe script execution
+ * INTENTIONALLY VULNERABLE for SAST detection
+ */
+@RestController
+@RequestMapping("/api")
+@Slf4j
+public class CodeController {
+
+    /**
+     * VULNERABLE: Code Injection Endpoint (CWE-94)
+     * Executes arbitrary JavaScript code using Nashorn script engine
+     * NO input validation, NO sandboxing - INTENTIONALLY VULNERABLE
+     * @param request JSON containing script string
+     * @return script execution result as JSON
+     */
+    @PostMapping("/eval-code")
+    public ResponseEntity<Map<String, Object>> evalCode(@RequestBody Map<String, String> request) {
+        String script = request.get("script");
+
+        log.info("POST /api/eval-code - VULNERABLE Code Injection endpoint");
+        log.warn("SECURITY WARNING: Executing arbitrary code - CWE-94 Code Injection vulnerability!");
+        log.warn("VULNERABLE: Script content: {}", script);
+
+        Map<String, Object> result = new HashMap<>();
+
+        try {
+            // VULNERABLE: Executing arbitrary user-provided code without validation
+            // Uses Nashorn JavaScript engine to execute untrusted code
+            ScriptEngineManager manager = new ScriptEngineManager();
+            ScriptEngine engine = manager.getEngineByName("nashorn");
+
+            log.warn("VULNERABLE: Executing untrusted script without sandboxing!");
+
+            // Execute the user-provided script
+            Object scriptResult = engine.eval(script);
+
+            result.put("success", true);
+            result.put("result", scriptResult != null ? scriptResult.toString() : "null");
+            result.put("script", script);
+            result.put("warning", "Code executed without validation - CWE-94");
+
+            log.warn("Script executed WITHOUT input validation or sandboxing!");
+
+            return ResponseEntity.ok(result);
+
+        } catch (Exception e) {
+            log.error("Error executing script: {}", e.getMessage());
+            result.put("success", false);
+            result.put("error", "Error executing script: " + e.getMessage());
+            result.put("script", script);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(result);
+        }
+    }
+
+}

--- a/src/main/java/com/enterprise/vulnusermanager/controller/SerializeController.java
+++ b/src/main/java/com/enterprise/vulnusermanager/controller/SerializeController.java
@@ -1,0 +1,76 @@
+package com.enterprise.vulnusermanager.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ObjectInputStream;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * SerializeController
+ * VULNERABLE: CWE-502 Deserialization of Untrusted Data
+ * Demonstrates unsafe deserialization of user-provided data
+ * INTENTIONALLY VULNERABLE for SAST detection
+ */
+@RestController
+@RequestMapping("/api")
+@Slf4j
+public class SerializeController {
+
+    /**
+     * VULNERABLE: Unsafe Deserialization Endpoint (CWE-502)
+     * Deserializes user-provided base64-encoded byte array
+     * Uses ObjectInputStream without validation - INTENTIONALLY VULNERABLE
+     * Allows arbitrary object deserialization leading to RCE
+     * @param request JSON containing base64-encoded serialized object
+     * @return deserialization result as JSON
+     */
+    @PostMapping("/deserialize-object")
+    public ResponseEntity<Map<String, Object>> deserializeObject(@RequestBody Map<String, String> request) {
+        String base64Data = request.get("data");
+
+        log.info("POST /api/deserialize-object - VULNERABLE Unsafe Deserialization endpoint");
+        log.warn("SECURITY WARNING: Deserializing untrusted data - CWE-502 Deserialization of Untrusted Data vulnerability!");
+
+        Map<String, Object> result = new HashMap<>();
+
+        try {
+            // VULNERABLE: Deserializing user-provided data without validation
+            // This can lead to Remote Code Execution (RCE) through gadget chains
+            byte[] data = Base64.getDecoder().decode(base64Data);
+
+            log.warn("VULNERABLE: Creating ObjectInputStream with user-provided data!");
+            log.warn("VULNERABLE: No type checking, no whitelist, no validation!");
+
+            // VULNERABLE: Unsafe deserialization
+            ByteArrayInputStream byteStream = new ByteArrayInputStream(data);
+            ObjectInputStream objectInputStream = new ObjectInputStream(byteStream);
+
+            // This can execute arbitrary code through deserialization gadgets
+            Object deserializedObject = objectInputStream.readObject();
+
+            objectInputStream.close();
+
+            result.put("success", true);
+            result.put("objectType", deserializedObject.getClass().getName());
+            result.put("objectValue", deserializedObject.toString());
+            result.put("warning", "Object deserialized without validation - CWE-502");
+
+            log.warn("Object deserialized WITHOUT validation: {}", deserializedObject.getClass().getName());
+
+            return ResponseEntity.ok(result);
+
+        } catch (Exception e) {
+            log.error("Error deserializing object: {}", e.getMessage());
+            result.put("success", false);
+            result.put("error", "Error deserializing object: " + e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(result);
+        }
+    }
+
+}

--- a/src/main/java/com/enterprise/vulnusermanager/controller/WebController.java
+++ b/src/main/java/com/enterprise/vulnusermanager/controller/WebController.java
@@ -1,0 +1,68 @@
+package com.enterprise.vulnusermanager.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * WebController
+ * VULNERABLE: CWE-918 Server-Side Request Forgery (SSRF)
+ * Demonstrates SSRF vulnerability through unvalidated URL fetching
+ * INTENTIONALLY VULNERABLE for SAST detection
+ */
+@RestController
+@RequestMapping("/api")
+@Slf4j
+public class WebController {
+
+    /**
+     * VULNERABLE: Server-Side Request Forgery (CWE-918)
+     * Fetches content from user-provided URL without validation
+     * Uses RestTemplate.getForObject() with untrusted URL
+     * NO URL whitelist, NO validation - INTENTIONALLY VULNERABLE
+     * @param url the URL to fetch (user-controlled)
+     * @return fetched content as JSON
+     */
+    @GetMapping("/fetch-url")
+    public ResponseEntity<Map<String, Object>> fetchUrl(@RequestParam String url) {
+        log.info("GET /api/fetch-url?url={} - VULNERABLE SSRF endpoint", url);
+        log.warn("SECURITY WARNING: Fetching untrusted URL - CWE-918 Server-Side Request Forgery vulnerability!");
+
+        Map<String, Object> result = new HashMap<>();
+
+        try {
+            // VULNERABLE: RestTemplate with user-provided URL
+            // No validation, no whitelist, no URL parsing
+            // Allows access to internal services, localhost, cloud metadata, etc.
+            log.warn("VULNERABLE: Fetching URL without validation: {}", url);
+            log.warn("VULNERABLE: Can access internal services, localhost, cloud metadata!");
+
+            RestTemplate restTemplate = new RestTemplate();
+
+            // VULNERABLE: Direct fetch without URL validation
+            String response = restTemplate.getForObject(url, String.class);
+
+            result.put("success", true);
+            result.put("url", url);
+            result.put("response", response);
+            result.put("warning", "URL fetched without validation - CWE-918");
+
+            log.warn("URL fetched WITHOUT validation or whitelist!");
+
+            return ResponseEntity.ok(result);
+
+        } catch (Exception e) {
+            log.error("Error fetching URL: {}", e.getMessage());
+            result.put("success", false);
+            result.put("url", url);
+            result.put("error", "Error fetching URL: " + e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(result);
+        }
+    }
+
+}

--- a/src/main/java/com/enterprise/vulnusermanager/service/UserService.java
+++ b/src/main/java/com/enterprise/vulnusermanager/service/UserService.java
@@ -28,15 +28,26 @@ public class UserService {
     private EntityManager entityManager;
 
     /**
-     * Save a new user to the database
+     * VULNERABLE: Save a new user to the database (CWE-20, CWE-200)
      * No password hashing - stored as plain text
+     * No input validation - accepts null/empty username
+     * Logs sensitive password information - INTENTIONALLY VULNERABLE
      * @param user the user to save
      * @return the saved user
      */
     @Transactional
     public User saveUser(User user) {
-        log.info("Saving user: {}", user.getUsername());
-        // No password encryption - intentionally vulnerable
+        // VULNERABLE CWE-200: Logging sensitive password information
+        log.info("Saving user {} with password {}",
+                user != null ? user.getUsername() : "null",
+                user != null ? user.getPassword() : "null");
+
+        log.warn("SECURITY WARNING: CWE-200 - Exposing password in logs!");
+        log.warn("SECURITY WARNING: CWE-20 - No input validation on username/password!");
+
+        // VULNERABLE CWE-20: No validation on input - accepts null/empty values
+        // VULNERABLE: No password encryption - intentionally vulnerable
+        // VULNERABLE: No check if user is null
         return userRepository.save(user);
     }
 

--- a/src/test/java/com/enterprise/vulnusermanager/VulnerableAppTest.java
+++ b/src/test/java/com/enterprise/vulnusermanager/VulnerableAppTest.java
@@ -1,0 +1,110 @@
+package com.enterprise.vulnusermanager;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * VulnerableAppTest
+ * Integration tests for the intentionally vulnerable application
+ * Tests demonstrate vulnerabilities without asserting success
+ * These tests verify that vulnerable endpoints are accessible
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+public class VulnerableAppTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    /**
+     * Test CWE-79 XSS vulnerability endpoint
+     * This test demonstrates that XSS payloads are accepted
+     * without sanitization or encoding
+     * NOTE: We're NOT asserting success - just checking endpoint accessibility
+     */
+    @Test
+    public void testXssProfileEndpoint_AcceptsScriptPayload() throws Exception {
+        // XSS payload - script tag that would execute in browser
+        String xssPayload = "<script>alert(1)</script>";
+
+        // Send request to vulnerable XSS endpoint
+        // The endpoint will render this unsafely in the template
+        mockMvc.perform(get("/api/xss-profile/" + xssPayload))
+                .andExpect(status().isOk()); // Endpoint is accessible
+
+        // NOTE: Not asserting that XSS is prevented - this is intentionally vulnerable
+        // A SAST tool should detect the use of th:utext in profile.html template
+    }
+
+    /**
+     * Test CWE-89 SQL Injection vulnerability endpoint
+     * This test demonstrates that SQL injection payloads are accepted
+     * without parameterization or sanitization
+     */
+    @Test
+    public void testSqlInjectionEndpoint_AcceptsMaliciousQuery() throws Exception {
+        // SQL injection payload
+        String sqlInjectionPayload = "' OR '1'='1";
+
+        // Send request to vulnerable SQL injection endpoint
+        mockMvc.perform(get("/api/search-users")
+                        .param("query", sqlInjectionPayload))
+                .andExpect(status().isOk()); // Endpoint is accessible
+
+        // NOTE: Not asserting SQL injection is prevented - intentionally vulnerable
+        // SAST tool should detect string concatenation in JPQL query
+    }
+
+    /**
+     * Test CWE-78 OS Command Injection vulnerability endpoint
+     * This test demonstrates the command injection endpoint is accessible
+     */
+    @Test
+    public void testCommandInjectionEndpoint_IsAccessible() throws Exception {
+        // Test that the vulnerable command injection endpoint exists
+        mockMvc.perform(get("/api/system-ping")
+                        .param("host", "localhost"))
+                .andExpect(status().isMethodNotAllowed()); // POST expected, not GET
+
+        // NOTE: Actual command injection test would require POST
+        // SAST tool should detect Runtime.exec() with string concatenation
+    }
+
+    /**
+     * Test CWE-22 Path Traversal vulnerability endpoint
+     * This test demonstrates that path traversal payloads are accepted
+     */
+    @Test
+    public void testPathTraversalEndpoint_AcceptsTraversalPayload() throws Exception {
+        // Path traversal payload
+        String pathTraversalPayload = "../../etc/passwd";
+
+        // Send request to vulnerable file download endpoint
+        mockMvc.perform(get("/api/download-file")
+                        .param("filename", pathTraversalPayload))
+                .andExpect(status().isOk()); // Endpoint is accessible
+
+        // NOTE: Not asserting path traversal is prevented - intentionally vulnerable
+        // SAST tool should detect unsanitized file path usage
+    }
+
+    /**
+     * Test that all users endpoint is publicly accessible
+     * Demonstrates CWE-862 Missing Authorization
+     */
+    @Test
+    public void testGetAllUsers_NoAuthenticationRequired() throws Exception {
+        // Should be protected but is publicly accessible
+        mockMvc.perform(get("/api/users"))
+                .andExpect(status().isOk()); // No authentication required
+
+        // NOTE: SAST tool should detect missing @PreAuthorize annotations
+    }
+
+}


### PR DESCRIPTION
## **User description**
This commit adds 10 new CWE vulnerabilities to the VulnUserManager application:

New Controllers:
- CodeController.java: CWE-94 Code Injection via Nashorn ScriptEngine
- AdminController.java: CWE-269 Improper Privilege Management with flawed role check
- SerializeController.java: CWE-502 Unsafe Deserialization of untrusted data
- WebController.java: CWE-918 Server-Side Request Forgery (SSRF)

Updated Controllers:
- UserController.java:
  * CWE-20 Improper Input Validation (accepts null/empty username)
  * CWE-863 Incorrect Authorization (flawed == string comparison)
- SystemController.java: CWE-77 OS Command Injection via ProcessBuilder
- ArrayController.java: CWE-119 Buffer Copy without size checking

Updated Services:
- UserService.java:
  * CWE-20 No validation on user input
  * CWE-200 Exposure of Sensitive Information (logs passwords)

Updated Security:
- SecurityConfig.java: CWE-287 Improper Authentication (NoOpPasswordEncoder, plain-text passwords)

Testing & Documentation:
- VulnerableAppTest.java: Integration tests demonstrating vulnerabilities
- README.md: Complete documentation with all endpoints and SonarQube scanning instructions

All implementations are intentionally vulnerable for educational purposes and SAST tool testing.


___

## **CodeAnt-AI Description**
**Add multiple deliberately vulnerable API endpoints, insecure auth, and comprehensive docs for SAST testing**

### What Changed
- Added several new API endpoints that accept and act on attacker-controlled input:
  - /api/eval-code now executes arbitrary JavaScript provided in requests.
  - /api/run-command accepts a command string and runs it on the host.
  - /api/deserialize-object accepts base64 blobs and deserializes them.
  - /api/fetch-url fetches content from any requested URL.
  - /api/buffer-copy copies incoming data into a fixed 5-character buffer (can overflow).
- Modified user and admin flows to be intentionally insecure:
  - /api/register accepts null or empty usernames and logs submitted passwords in plain text.
  - /api/admin-only performs admin actions using a manual role string check that can be bypassed.
  - /api/edit-user uses a flawed string comparison for authorization, allowing incorrect authorization outcomes.
  - /api/users and DELETE /api/users/{id} remain publicly accessible with no authorization checks.
- Changed application security behavior:
  - CSRF protection is disabled and HTTP Basic is configured with plain-text passwords and in-memory hardcoded users, making state-changing requests and credentials insecure.
- Tests and documentation:
  - Added integration tests that exercise and verify the vulnerable endpoints are reachable.
  - Expanded README with endpoint examples, instructions to run the app and scan with SonarQube, and a catalog of the demonstrated CWEs.

### Impact
`✅ Reproducible code-injection and remote-execution endpoints for SAST`
`✅ Demonstrable unsafe deserialization and command-execution scenarios`
`✅ Publicly accessible vulnerable endpoints with runnable docs and tests`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
